### PR TITLE
Adds access to `n_initial_points` in Bounce

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pymoo
 torch
 botorch
 cma
+mol_ga

--- a/src/poli_baselines/core/abstract_solver.py
+++ b/src/poli_baselines/core/abstract_solver.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Union
 
 import numpy as np
@@ -9,8 +10,8 @@ class AbstractSolver:
     def __init__(
         self,
         black_box: AbstractBlackBox,
-        x0: Union[np.ndarray, None] = None,
-        y0: Union[np.ndarray, None] = None,
+        x0: np.ndarray | None = None,
+        y0: np.ndarray | None = None,
     ):
         self.black_box = black_box
         self.x0 = x0
@@ -20,7 +21,7 @@ class AbstractSolver:
         self,
         max_iter: int = 100,
         n_initial_points: int = 0,
-        seed: int = None,
+        seed: int | None = None,
     ) -> None:
         """
         Optimizes the problem for a given number of iterations.

--- a/src/poli_baselines/core/utils/bounce/poli_benchmark.py
+++ b/src/poli_baselines/core/utils/bounce/poli_benchmark.py
@@ -1,0 +1,116 @@
+"""
+This can run inside the bounce env.
+"""
+
+from __future__ import annotations
+import numpy as np
+import torch
+
+from poli.core.abstract_black_box import AbstractBlackBox
+from poli.repository import ToyContinuousBlackBox
+
+from bounce.util.benchmark import Parameter, ParameterType
+
+from bounce.benchmarks import SyntheticBenchmark
+
+
+class PoliBenchmark(SyntheticBenchmark):
+    def __init__(
+        self,
+        f: AbstractBlackBox,
+        noise_std: float,
+        *args,
+        sequence_length: int | None = None,
+        alphabet: list[str] | None = None,
+        **kwargs,
+    ):
+        # Depending on the nature of the problem, build the
+        # parameters.
+        self.f = f
+        if f.info.is_discrete():
+            if alphabet is None:
+                assert f.info.alphabet is not None or not f.info.is_discrete()
+                alphabet = f.info.alphabet
+            self.alphabet_i_to_s = {
+                index: token for index, token in enumerate(alphabet)
+            }
+            self.alphabet_s_to_i = {
+                token: index for index, token in enumerate(alphabet)
+            }
+            self.n_realizations = len(alphabet)
+        else:
+            assert alphabet is None
+            self.alphabet_i_to_s = None
+            self.alphabet_s_to_i = None
+            self.n_realizations = None
+
+        parameters = self.build_parameters(f, sequence_length=sequence_length)
+        super().__init__(parameters, noise_std, *args, **kwargs)
+
+    def _call_discrete(self, x: np.ndarray) -> np.ndarray:
+        assert x.ndim == 1
+        assert self.f.info.is_discrete()
+        start = 0
+        _x = []
+        for parameter in self.parameters:
+            end = start + parameter.dims_required
+            one_hot = x[start:end]
+            # transform onehot to categorical
+            cat = torch.argmax(one_hot)
+            token = self.alphabet_i_to_s[int(cat.item())]
+            _x.append(token)
+            start = end
+        _x = np.array(_x)
+
+        # TODO: is Bounce maximizing or minimizing?
+        return -self.f(_x.reshape(1, -1)).flatten()
+
+    def _call_continuous(self, x: np.ndarray) -> np.ndarray:
+        assert x.ndim == 1
+        # TODO: is Bounce maximizing or minimizing?
+        return -self.f(x.reshape(1, -1)).flatten()
+
+    def __call__(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        call_function = (
+            self._call_discrete if self.f.info.is_discrete() else self._call_continuous
+        )
+        y_ = [call_function(x_i) for x_i in x]
+        y = np.vstack(y_)
+        return torch.tensor(y)
+
+    def build_parameters(self, f: AbstractBlackBox, sequence_length: int = None):
+        if f.info.is_discrete():
+            return self._build_discrete_parameters(f, sequence_length)
+        else:
+            return self._build_continuous_parameters(f)
+
+    def _build_continuous_parameters(self, f: ToyContinuousBlackBox):
+        lower_bound, upper_bound = f.bounds
+        return [
+            Parameter(
+                name=f"x{i}",
+                type=ParameterType.CONTINUOUS,
+                lower_bound=lower_bound,
+                upper_bound=upper_bound,
+            )
+            for i in range(f.n_dimensions)
+        ]
+
+    def _build_discrete_parameters(
+        self, f: AbstractBlackBox, sequence_length: int | None = None
+    ):
+        if sequence_length is None:
+            if not isinstance(f, ToyContinuousBlackBox):
+                sequence_length = f.info.max_sequence_length
+
+                assert sequence_length < float("inf")
+
+        return [
+            Parameter(
+                name=f"x{i}",
+                type=ParameterType.CATEGORICAL,
+                lower_bound=0,
+                upper_bound=self.n_realizations - 1,
+            )
+            for i in range(sequence_length)
+        ]

--- a/src/poli_baselines/solvers/bayesian_optimization/bounce/solver.py
+++ b/src/poli_baselines/solvers/bayesian_optimization/bounce/solver.py
@@ -2,46 +2,46 @@
 This can run inside the bounce env.
 """
 
+from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
 import numpy as np
 import torch
 
+from poli.core.util.seeding import seed_python_numpy_and_torch
 from poli.core.abstract_black_box import AbstractBlackBox
 from poli_baselines.core.abstract_solver import AbstractSolver
+from poli_baselines.core.utils.bounce.poli_benchmark import PoliBenchmark
+
+from bounce.bounce import Bounce
 
 ROOT_DIR = Path(__file__).parent.parent.parent.parent.parent.parent.resolve()
-
-from bounce.benchmarks import PoliBenchmark
-from bounce.bounce import Bounce
 
 
 class BounceSolver(AbstractSolver):
     def __init__(
         self,
         black_box: AbstractBlackBox,
-        x0: np.ndarray,
-        y0: np.ndarray,
         noise_std: float = 0.0,
         sequence_length: int | None = None,
-        alphabet: dict[str, int] | None = None,
+        alphabet: list[str] | None = None,
         device: str | None = None,
         dtype: Literal["float32", "float64"] = "float32",
         batch_size: int = 1,
-        number_initial_points: int = 2,
+        n_initial_points: int | None = None,
         initial_target_dimensionality: int = 2,
         number_new_bins_on_split: int = 2,
     ):
-        super().__init__(black_box, x0, y0)
+        super().__init__(black_box, None, None)
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = device
         self.dtype = dtype
         self.batch_size = batch_size
-        self.number_initial_points = number_initial_points
         self.initial_target_dimensionality = initial_target_dimensionality
         self.number_new_bins_on_split = number_new_bins_on_split
+        self.n_initial_points = n_initial_points
 
         self.benchmark = PoliBenchmark(
             f=black_box,
@@ -58,10 +58,25 @@ class BounceSolver(AbstractSolver):
         with open(results_dir / ".gitignore", "w") as fp:
             fp.write("*\n!.gitignore")
 
-    def solve(self, max_iter: int) -> None:
+    def solve(
+        self,
+        max_iter: int = 100,
+        n_initial_points: int | None = None,
+        seed: int | None = None,
+    ) -> None:
+        if seed is not None:
+            seed_python_numpy_and_torch(seed)
+
+        if n_initial_points is None:
+            if self.n_initial_points is None:
+                raise ValueError(
+                    "n_initial_points must be set, either in init or in solve"
+                )
+            n_initial_points = self.n_initial_points
+
         self.bounce = Bounce(
             benchmark=self.benchmark,
-            number_initial_points=self.number_initial_points,
+            number_initial_points=n_initial_points,
             initial_target_dimensionality=self.initial_target_dimensionality,
             number_new_bins_on_split=self.number_new_bins_on_split,
             maximum_number_evaluations=max_iter,

--- a/src/poli_baselines/tests/solvers/bayesian_optimization/test_ax_solvers.py
+++ b/src/poli_baselines/tests/solvers/bayesian_optimization/test_ax_solvers.py
@@ -47,11 +47,11 @@ class TestBayesianOptimization:
     def test_solving_while_mocking_training(self, solver, solver_kwargs):
         f, x0 = self.problem.black_box, self.problem.x0
         y0 = f(x0)
-        solver: AbstractSolver = solver(
+        solver_: AbstractSolver = solver(
             black_box=f,
             x0=x0,
             y0=y0,
             **solver_kwargs,
         )
 
-        solver.solve(max_iter=2)
+        solver_.solve(max_iter=2)

--- a/src/poli_baselines/tests/solvers/bayesian_optimization/test_bounce.py
+++ b/src/poli_baselines/tests/solvers/bayesian_optimization/test_bounce.py
@@ -47,18 +47,13 @@ def test_bounce_runs():
     problem = objective_factory.create(
         name="rdkit_qed", string_representation="SELFIES"
     )
-    black_box, x0 = problem.black_box, problem.x0
-    y0 = black_box(x0)
-
-    x0_ = np.array([["[nop]"] * sequence_length])
-    x0_[0, : x0.shape[1]] = x0
+    black_box = problem.black_box
 
     solver = BounceSolver(
         black_box=black_box,
-        x0=x0_,
-        y0=y0,
         alphabet=alphabet,
         sequence_length=sequence_length,
+        n_initial_points=10,
     )
 
     assert solver is not None


### PR DESCRIPTION
For now, Bounce can't give access to custom initializations. This PR removes the inputs `x0` and `y0` from the `BounceSolver`, and adds more flags for `n_initial_points`.