### PR TITLE
[tuning] add lambo ehrlich example, tune params

### DIFF
--- a/examples/06_running_lambo2_on_rasp/run.py
+++ b/examples/06_running_lambo2_on_rasp/run.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import matplotlib.pyplot as plt
+import torch
 
 from poli.objective_repository import RaspProblemFactory
 from poli_baselines.solvers.bayesian_optimization.lambo2 import LaMBO2
@@ -33,19 +34,24 @@ def run_with_default_hyperparameters():
     observer.x_s.append(x0.reshape(-1, 1))
     observer.y_s.append(y0)
 
+    torch.set_float32_matmul_precision('medium')
     lambo2 = LaMBO2(
         black_box=black_box,
         x0=x0,
         y0=y0,
+        overrides=["max_epochs=2"],
+        max_epochs_for_retraining=8,
     )
-
-    lambo2.solve(max_iter=10)
+    lambo2.solve(max_iter=32)
 
     fig, (ax1, ax2) = plt.subplots(1, 2)
     plot_best_y(observer, ax1)
     plot_best_y(observer, ax2, start_from=x0.shape[0])
     ax1.axvline(x0.shape[0], color="red")
     plt.show()
+
+    print("Best starting obj value: ", np.max(y0))
+    print("Best final obj value: ", np.max(lambo2.history_for_training["y"]))
 
     black_box.terminate()
 
@@ -107,5 +113,5 @@ def run_with_modified_hyperparameters():
 
 
 if __name__ == "__main__":
-    # run_with_default_hyperparameters()
-    run_with_modified_hyperparameters()
+    run_with_default_hyperparameters()
+    # run_with_modified_hyperparameters()

--- a/examples/07_running_lambo2_on_ehrlich/run.py
+++ b/examples/07_running_lambo2_on_ehrlich/run.py
@@ -1,0 +1,74 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+import torch
+
+from poli.objective_repository import EhrlichProblemFactory
+from poli_baselines.solvers.bayesian_optimization.lambo2 import LaMBO2
+from poli_baselines.solvers.simple.genetic_algorithm import FixedLengthGeneticAlgorithm
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.append(str(THIS_DIR))
+
+from simple_observer import SimpleObserver, plot_best_y
+
+
+def run_with_default_hyperparameters():
+    problem = EhrlichProblemFactory().create(
+        sequence_length=32,
+        motif_length=4,
+        n_motifs=4,
+        quantization=4,
+        return_value_on_unfeasible=-1.0
+    )
+    black_box = problem.black_box
+    x0 = problem.x0
+    random_seqs = np.array([list(black_box._sample_random_sequence()) for _ in range(31)])
+    x0 = np.concatenate([problem.x0, random_seqs], axis=0)
+    y0 = black_box(x0)
+
+    observer = SimpleObserver()
+    black_box.set_observer(observer)
+
+    # arr = np.load(THIS_DIR / "rasp_seed_data.npz")
+    # x0 = arr["x0"]
+    # y0 = arr["y0"]
+
+    observer.x_s.append(x0.reshape(-1, 1))
+    observer.y_s.append(y0)
+
+    presolver = FixedLengthGeneticAlgorithm(
+        black_box=black_box,
+        x0=x0,
+        y0=y0,
+        population_size=2000,
+        prob_of_mutation=0.04
+    )
+    presolver.solve(max_iter=10)
+    presolver_x = np.array(presolver.history["x"])
+    presolver_x = presolver_x.reshape(presolver_x.shape[0], -1)
+
+    # import pdb; pdb.set_trace()
+    torch.set_float32_matmul_precision('medium')
+    lambo2 = LaMBO2(
+        black_box=black_box,
+        x0=presolver_x,  # inconsistent API
+        overrides=["max_epochs=2"],
+        max_epochs_for_retraining=8,
+    )
+
+    lambo2.solve(max_iter=32)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    plot_best_y(observer, ax1)
+    plot_best_y(observer, ax2, start_from=x0.shape[0])
+    ax1.axvline(x0.shape[0], color="red")
+    plt.show()
+
+    black_box.terminate()
+
+
+if __name__ == "__main__":
+    run_with_default_hyperparameters()

--- a/examples/07_running_lambo2_on_ehrlich/run.py
+++ b/examples/07_running_lambo2_on_ehrlich/run.py
@@ -19,13 +19,13 @@ def run_with_default_hyperparameters():
     problem = EhrlichProblemFactory().create(
         sequence_length=32,
         motif_length=4,
-        n_motifs=4,
+        n_motifs=2,
         quantization=4,
         return_value_on_unfeasible=-1.0
     )
     black_box = problem.black_box
     x0 = problem.x0
-    random_seqs = np.array([list(black_box._sample_random_sequence()) for _ in range(31)])
+    random_seqs = np.array([list(black_box._sample_random_sequence()) for _ in range(127)])
     x0 = np.concatenate([problem.x0, random_seqs], axis=0)
     y0 = black_box(x0)
 
@@ -43,10 +43,10 @@ def run_with_default_hyperparameters():
         black_box=black_box,
         x0=x0,
         y0=y0,
-        population_size=2000,
-        prob_of_mutation=0.04
+        population_size=128,
+        prob_of_mutation=0.4
     )
-    presolver.solve(max_iter=10)
+    presolver.solve(max_iter=1)
     presolver_x = np.array(presolver.history["x"])
     presolver_x = presolver_x.reshape(presolver_x.shape[0], -1)
 

--- a/examples/07_running_lambo2_on_ehrlich/simple_observer.py
+++ b/examples/07_running_lambo2_on_ehrlich/simple_observer.py
@@ -1,0 +1,27 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from poli.core.black_box_information import BlackBoxInformation
+from poli.core.util.abstract_observer import AbstractObserver
+
+
+class SimpleObserver(AbstractObserver):
+    def __init__(self) -> None:
+        self.x_s = []
+        self.y_s = []
+        super().__init__()
+
+    def initialize_observer(
+        self, problem_setup_info: BlackBoxInformation, caller_info: object, seed: int
+    ) -> object: ...
+
+    def observe(self, x: np.ndarray, y: np.ndarray, context=None) -> None:
+        self.x_s.append(x)
+        self.y_s.append(y)
+
+
+def plot_best_y(obs: SimpleObserver, ax: plt.Axes, start_from: int = 0):
+    best_y = np.maximum.accumulate(np.vstack(obs.y_s).flatten())
+    ax.plot(best_y.flatten()[start_from:])
+    ax.set_xlabel("Number of evaluations")
+    ax.set_ylabel("Best value found")

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/branches/protein_constraint.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/branches/protein_constraint.yaml
@@ -1,4 +1,4 @@
-protein_property:
+protein_constraint:
   _target_: cortex.model.branch.Conv1dBranch
   out_dim: 8
   channel_dim: ${feature_dim}

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
@@ -2,8 +2,9 @@ defaults:
   - tree: sequence_model_conservative
   - roots: [protein_seq]
   - trunk: sum_trunk
-  - branches: [protein_property, protein_generation]
+  - branches: [protein_property, protein_generation, protein_constraint]
   - tasks:
+    - generic_constraint
     - generic_task
     - protein_seq
   - guidance_objective: generic_task
@@ -16,11 +17,14 @@ max_epochs: 1
 data_dir: ./.cache
 wandb_mode: offline
 random_seed: 42
-num_steps: 1
-num_samples: 16
+num_steps: 2
+num_samples: 32
 allow_length_change: false
 
 trainer:
   _target_: lightning.Trainer
   max_epochs: ${max_epochs}
-  num_sanity_val_steps: 1
+  num_sanity_val_steps: 0
+  accelerator: gpu
+  devices: 1
+  precision: 16

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
@@ -10,15 +10,15 @@ defaults:
   - guidance_objective: generic_task
   - optim: lambo_conservative
 
-feature_dim: 32
+feature_dim: 128
 kernel_size: 3
-batch_size: 32
+batch_size: 128
 max_epochs: 1
 data_dir: ./.cache
 wandb_mode: offline
 random_seed: 42
 num_steps: 2
-num_samples: 32
+num_samples: ${batch_size}
 allow_length_change: false
 
 trainer:

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/generic_training.yaml
@@ -2,9 +2,10 @@ defaults:
   - tree: sequence_model_conservative
   - roots: [protein_seq]
   - trunk: sum_trunk
-  - branches: [protein_property, protein_generation, protein_constraint]
+  # - branches: [protein_property, protein_generation, protein_constraint]
+  - branches: [protein_property, protein_generation]
   - tasks:
-    - generic_constraint
+    # - generic_constraint
     - generic_task
     - protein_seq
   - guidance_objective: generic_task
@@ -17,7 +18,7 @@ max_epochs: 1
 data_dir: ./.cache
 wandb_mode: offline
 random_seed: 42
-num_steps: 2
+num_steps: 1
 num_samples: ${batch_size}
 allow_length_change: false
 

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/guidance_objective/generic_task.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/guidance_objective/generic_task.yaml
@@ -3,7 +3,9 @@ static_kwargs:
   _target_: cortex.acquisition.GraphNEI
   objectives:
     - generic_task
-  constraints: null
+  constraints:
+    generic_task:
+      - generic_constraint
   scaling: null
 runtime_kwargs:
   _target_: cortex.acquisition.get_graph_nei_runtime_kwargs

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/guidance_objective/generic_task.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/guidance_objective/generic_task.yaml
@@ -3,9 +3,9 @@ static_kwargs:
   _target_: cortex.acquisition.GraphNEI
   objectives:
     - generic_task
-  constraints:
-    generic_task:
-      - generic_constraint
+  constraints: null
+    # generic_task:
+      # - generic_constraint
   scaling: null
 runtime_kwargs:
   _target_: cortex.acquisition.get_graph_nei_runtime_kwargs

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/optim/lambo_conservative.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/optim/lambo_conservative.yaml
@@ -12,7 +12,7 @@ num_mutations_per_step: 2
 # As few as you can get away with.
 # It depends on the number of mutations you want
 # to make per step.
-max_guidance_updates: 4
+max_guidance_updates: 8
 
 # Good to leave it still.
 # (It's the gradient descent param.)
@@ -28,7 +28,7 @@ guidance_layer: trunk
 kl_weight: 0.0
 
 # Deprecated. Legacy flag.
-feature_attr_temp: 8.0
+feature_attr_temp: 1.0
 
 # Leave it still.
 domain_name: protein_seq

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/optim/lambo_conservative.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/optim/lambo_conservative.yaml
@@ -12,7 +12,7 @@ num_mutations_per_step: 2
 # As few as you can get away with.
 # It depends on the number of mutations you want
 # to make per step.
-max_guidance_updates: 1
+max_guidance_updates: 4
 
 # Good to leave it still.
 # (It's the gradient descent param.)
@@ -28,7 +28,7 @@ guidance_layer: trunk
 kl_weight: 0.0
 
 # Deprecated. Legacy flag.
-feature_attr_temp: 1.0
+feature_attr_temp: 8.0
 
 # Leave it still.
 domain_name: protein_seq

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
@@ -1,17 +1,19 @@
-protein_property:
-  generic_task:
-    _target_: cortex.task.RegressionTask
+protein_constraint:
+  generic_constraint:
+    _target_: cortex.task.ClassificationTask
     input_map:
       protein_seq: ['tokenized_seq']
-    outcome_cols: ['generic_task']
+    class_col: is_feasible
+    num_classes: 2
     corrupt_train_inputs: true
     root_key: protein_seq
-    nominal_label_var: 0.01
     ensemble_size: 4
     data_module:
       _target_: cortex.data.data_module.TaskDataModule
       _recursive_: false
       lengths: [1.0, 0.0]
+      balance_train_partition:
+        - ${tasks.protein_constraint.generic_constraint.class_col}
       batch_size: ${batch_size}
       dataset_config:
         _target_: cortex.data.dataset.NumpyDataset

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
@@ -7,7 +7,7 @@ protein_constraint:
     num_classes: 2
     corrupt_train_inputs: true
     root_key: protein_seq
-    ensemble_size: 4
+    ensemble_size: 8
     data_module:
       _target_: cortex.data.data_module.TaskDataModule
       _recursive_: false

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_constraint.yaml
@@ -14,6 +14,7 @@ protein_constraint:
       lengths: [1.0, 0.0]
       balance_train_partition:
         - ${tasks.protein_constraint.generic_constraint.class_col}
+        - recency
       batch_size: ${batch_size}
       dataset_config:
         _target_: cortex.data.dataset.NumpyDataset

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_task.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_task.yaml
@@ -7,7 +7,7 @@ protein_property:
     corrupt_train_inputs: true
     root_key: protein_seq
     nominal_label_var: 0.01
-    ensemble_size: 4
+    ensemble_size: 8
     data_module:
       _target_: cortex.data.data_module.TaskDataModule
       _recursive_: false

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_task.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/generic_task.yaml
@@ -12,6 +12,8 @@ protein_property:
       _target_: cortex.data.data_module.TaskDataModule
       _recursive_: false
       lengths: [1.0, 0.0]
+      balance_train_partition:
+        - recency
       batch_size: ${batch_size}
       dataset_config:
         _target_: cortex.data.dataset.NumpyDataset

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/protein_seq.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tasks/protein_seq.yaml
@@ -12,7 +12,7 @@ protein_generation:
       _recursive_: false
       batch_size: ${batch_size}
       balance_train_partition: null
-      drop_last: true
+      drop_last: false
       lengths: [1.0, 0.0]
       train_on_everything: false
       num_workers: 1

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tree/sequence_model_conservative.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tree/sequence_model_conservative.yaml
@@ -6,12 +6,12 @@ fit_cfg:
   weight_averaging: null
   optimizer:
     _target_: torch.optim.Adam
-    lr: 3e-4
+    lr: 5e-3
     weight_decay: 0.
     betas: [0.9, 0.99]
     fused: false
   lr_scheduler:
-    # _target_: transformers.get_cosine_schedule_with_warmup
-    # num_warmup_steps: 1
-    # num_training_steps: ${max_epochs}
-    _target_: transformers.get_constant_schedule
+    _target_: transformers.get_cosine_schedule_with_warmup
+    num_warmup_steps: 2
+    num_training_steps: ${max_epochs}
+    # _target_: transformers.get_constant_schedule

--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tree/sequence_model_conservative.yaml
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/hydra_configs/tree/sequence_model_conservative.yaml
@@ -6,11 +6,12 @@ fit_cfg:
   weight_averaging: null
   optimizer:
     _target_: torch.optim.Adam
-    lr: 5e-3
+    lr: 3e-4
     weight_decay: 0.
-    betas: [0.99, 0.999]
+    betas: [0.9, 0.99]
     fused: false
   lr_scheduler:
-    _target_: transformers.get_cosine_schedule_with_warmup
-    num_warmup_steps: 1
-    num_training_steps: ${max_epochs}
+    # _target_: transformers.get_cosine_schedule_with_warmup
+    # num_warmup_steps: 1
+    # num_training_steps: ${max_epochs}
+    _target_: transformers.get_constant_schedule


### PR DESCRIPTION
This PR is mainly for visibility, we can talk about which (if any) of these changes we want to keep

Changes:

- Add LaMBO-2/Ehrlich example script
- Add genetic algorithm presolver to example
- Add constraint task, modify guidance signal config to include the constraint classifier
- Add more random restarts to initial solution
- Add ranked FFT from `beignet` to help prevent generative head collapse
- Increase training duration
- Increase number of ensemble components
- Train discriminators on corrupted inputs
- Switch trainer to mixed-precision on GPU


Note: requires updates from [this cortex PR](https://github.com/prescient-design/cortex/pull/16) to run