### PR TITLE
Adds explicit `weights_only` flag in model loading

### DIFF
--- a/src/poli_baselines/solvers/bayesian_optimization/lambo2/solver.py
+++ b/src/poli_baselines/solvers/bayesian_optimization/lambo2/solver.py
@@ -213,6 +213,7 @@ class LaMBO2(AbstractSolver):
                 torch.load(
                     load_checkpoint_from,
                     map_location="cpu",
+                    weights_only=False,
                 )["state_dict"]
             )
 


### PR DESCRIPTION
In `torch==2.6`, they changed to a default `weights_only=True` in the `torch.load` function. Since the LaMBO2 model stores configs we need to impose `weights_only=False`.